### PR TITLE
Django 3 Compatibility #100

### DIFF
--- a/django_fsm_log/models.py
+++ b/django_fsm_log/models.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 from django.utils.timezone import now
 from django_fsm import FSMFieldMixin, FSMIntegerField
 
@@ -12,7 +12,6 @@ from .conf import settings
 from .managers import StateLogManager
 
 
-@python_2_unicode_compatible
 class StateLog(models.Model):
     timestamp = models.DateTimeField(default=now)
     by = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), blank=True,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readfile(filename):
 
 setup(
     name='django-fsm-log',
-    version='1.6.2',
+    version='1.7.0',
     description='Logging for django-fsm',
     long_description=readfile('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR is to document why I forked django-fsm-log.

- package does not work with Django 3
- project is looking for new maintainers and has not released in a while

Will try to keep maintaining this branch for Django 3 compatibility until https://github.com/gizmag/django-fsm-log/issues/98 is closed.

### Releases

- `django-fsm-log==1.7.0`

### Installation instrunctions

Add following line to `requirements.txt`

```
git+https://github.com/alysivji/django-fsm-log.git@1.7.0#egg=django-fsm-log==1.7.0
```